### PR TITLE
Fix: Stop button showing timeout error after stopping the simulation

### DIFF
--- a/simulation_and_control_panel/backend/Controllers/data_controller.py
+++ b/simulation_and_control_panel/backend/Controllers/data_controller.py
@@ -88,7 +88,8 @@ class DataController:
             "is_running": self.sim_controller.is_running,
             "is_paused": self.sim_controller.is_paused,
             "current_step": self.sim_controller.current_step,
-            "auto_stepping": self.sim_controller.auto_stepping
+            "auto_stepping": self.sim_controller.auto_stepping,
+            "stopping": self.sim_controller.stopping
         }
     
     def get_vehicle_count(self):

--- a/simulation_and_control_panel/backend/Controllers/simulation_controller.py
+++ b/simulation_and_control_panel/backend/Controllers/simulation_controller.py
@@ -28,6 +28,7 @@ class SimulationController:
         self.auto_stepping = False
         self.auto_step_thread = None
         self.step_lock = threading.Lock()  # Lock for thread-safe stepping
+        self.stopping = False  # True while background teardown is in progress
         self.optimizer = None
         self.optimization_enabled = False
         self.action_interval = 15
@@ -465,6 +466,9 @@ class SimulationController:
 
     def start(self):
         """Start the simulation"""
+        if self.stopping:
+            return {"status": "error", "message": "Simulation is still shutting down, please wait a moment"}
+
         if self.is_running:
             return {"status": "error", "message": "Simulation already running"}
             
@@ -613,18 +617,37 @@ class SimulationController:
         """Stop and close simulation"""
         if not self.is_running:
             return {"status": "error", "message": "Simulation not running"}
-            
-        try:
-            self.auto_stepping = False
-            if self.auto_step_thread:
-                self.auto_step_thread.join(timeout=2)
-            
-            traci.close()
-            self.is_running = False
-            self.is_paused = False
-            self.current_step = 0
-            print("Simulation stopped")
-            return {"status": "success", "message": "Simulation stopped"}
-        except Exception as e:
-            return {"status": "error", "message": str(e)}
+
+        if self.stopping:
+            return {"status": "error", "message": "Simulation is already shutting down"}
+
+        # Immediately update state so no new steps / starts can be issued
+        self.auto_stepping = False
+        self.is_running = False
+        self.is_paused = False
+        self.stopping = True
+
+        # Capture thread reference before clearing it
+        auto_step_thread = self.auto_step_thread
+
+        def _teardown():
+            """Run blocking SUMO teardown in background so the HTTP response returns fast."""
+            try:
+                # Wait for the auto-step loop to exit (it checks is_running / auto_stepping)
+                if auto_step_thread and auto_step_thread.is_alive():
+                    auto_step_thread.join(timeout=2)
+
+                # traci.close() blocks until SUMO fully exits — safe to do here in background
+                traci.close()
+                self.current_step = 0
+                print("Simulation stopped (teardown complete)")
+            except Exception as e:
+                print(f"Error during simulation teardown: {e}")
+            finally:
+                self.stopping = False
+
+        teardown_thread = threading.Thread(target=_teardown, daemon=True)
+        teardown_thread.start()
+
+        return {"status": "success", "message": "Simulation stopped"}
     

--- a/simulation_and_control_panel/backend/app.py
+++ b/simulation_and_control_panel/backend/app.py
@@ -21,8 +21,8 @@ socketio = SocketIO(app, cors_allowed_origins="*", async_mode='threading')
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 # CHANGE THIS to your actual config file!
 # CONFIG_FILE = os.path.join(BASE_DIR, "..", "scenarios", "mapishara.sumo.cfg")
-#CONFIG_FILE = os.path.join(BASE_DIR, "..", "scenarios", "grid3x3", "grid3x3.sumo.cfg")
-CONFIG_FILE = os.path.join(BASE_DIR, "..", "..", "services", "emergency_vehicle_preemption", "simulation", "config", "katunayake.sumocfg")
+CONFIG_FILE = os.path.join(BASE_DIR, "..", "scenarios", "grid3x3", "grid3x3.sumo.cfg")
+# CONFIG_FILE = os.path.join(BASE_DIR, "..", "..", "services", "emergency_vehicle_preemption", "simulation", "config", "katunayake.sumocfg")
 
 # Initialize controllers
 green_wave_controller = GreenWaveController(use_gui=config.USE_GUI)

--- a/simulation_and_control_panel/backend/app.py
+++ b/simulation_and_control_panel/backend/app.py
@@ -21,8 +21,8 @@ socketio = SocketIO(app, cors_allowed_origins="*", async_mode='threading')
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 # CHANGE THIS to your actual config file!
 # CONFIG_FILE = os.path.join(BASE_DIR, "..", "scenarios", "mapishara.sumo.cfg")
-CONFIG_FILE = os.path.join(BASE_DIR, "..", "scenarios", "grid3x3", "grid3x3.sumo.cfg")
-# CONFIG_FILE = os.path.join(BASE_DIR, "..", "..", "services", "emergency_vehicle_preemption", "simulation", "config", "katunayake.sumocfg")
+# CONFIG_FILE = os.path.join(BASE_DIR, "..", "scenarios", "grid3x3", "grid3x3.sumo.cfg")
+CONFIG_FILE = os.path.join(BASE_DIR, "..", "..", "services", "emergency_vehicle_preemption", "simulation", "config", "katunayake.sumocfg")
 
 # Initialize controllers
 green_wave_controller = GreenWaveController(use_gui=config.USE_GUI)

--- a/simulation_and_control_panel/frontend/src/App.tsx
+++ b/simulation_and_control_panel/frontend/src/App.tsx
@@ -12,6 +12,7 @@ function App() {
     is_paused: false,
     current_step: 0,
     auto_stepping: false,
+    stopping: false,
   })
 
   useEffect(() => {
@@ -92,6 +93,11 @@ function App() {
                   {simulationStatus.auto_stepping ? '✓' : '✗'}
                 </p>
               </div>
+              {simulationStatus.stopping && (
+                <div className="bg-orange-50 p-4 rounded col-span-2 md:col-span-4">
+                  <p className="text-orange-700 text-sm font-medium animate-pulse">⏳ Waiting for SUMO to fully close...</p>
+                </div>
+              )}
             </div>
           </div>
         )}
@@ -132,6 +138,7 @@ function App() {
               onRefresh={fetchStatus}
               isRunning={simulationStatus.is_running}
               isPaused={simulationStatus.is_paused}
+              isStopping={simulationStatus.stopping}
             />
             
             {mode === 'manual' && (

--- a/simulation_and_control_panel/frontend/src/components/SimulationLifecycle.tsx
+++ b/simulation_and_control_panel/frontend/src/components/SimulationLifecycle.tsx
@@ -5,12 +5,14 @@ interface SimulationLifecycleProps {
   onRefresh?: () => void
   isRunning?: boolean
   isPaused?: boolean
+  isStopping?: boolean
 }
 
 export function SimulationLifecycle({
   onRefresh,
   isRunning = false,
   isPaused = false,
+  isStopping = false,
 }: SimulationLifecycleProps) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -41,10 +43,10 @@ export function SimulationLifecycle({
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         <button
           onClick={() => handleAction(startSimulation, 'Start')}
-          disabled={loading || isRunning}
+          disabled={loading || isRunning || isStopping}
           className="bg-green-600 hover:bg-green-700 disabled:bg-gray-400 text-white font-semibold py-3 px-4 rounded transition"
         >
-          Start
+          {isStopping ? 'Closing...' : 'Start'}
         </button>
 
         <button


### PR DESCRIPTION
Description

The issue was clicking "Stop" would successfully stop SUMO but the control panel displayed a "Stop failed: timeout of 5000ms exceeded" error message because the backend took too long to respond.
The stop process is now handled in the background so the response returns immediately. The Start button is also disabled with a "Closing..." label until SUMO has fully shut down, preventing any issues from starting a new simulation too quickly.